### PR TITLE
Player hit shader

### DIFF
--- a/Player.cs
+++ b/Player.cs
@@ -29,6 +29,7 @@ public partial class Player : Area2D
 	private void OnBodyEntered(Node2D body)
 	{
 		TriggerExplosion();
+		GetNode<AnimationPlayer>("HitAnimationPlayer").Play("hit");
 		// TODO: Trigger way to flash Player sprite
 		EmitSignal(SignalName.Hit);
 		body.QueueFree();

--- a/Player.tscn
+++ b/Player.tscn
@@ -1,9 +1,15 @@
-[gd_scene load_steps=6 format=3 uid="uid://dl6ceir5rfv5j"]
+[gd_scene load_steps=11 format=3 uid="uid://dl6ceir5rfv5j"]
 
 [ext_resource type="Script" path="res://Player.cs" id="1_1tq4h"]
 [ext_resource type="Texture2D" uid="uid://lebof3107ub2" path="res://art/SpaceFighter.png" id="1_a4yoe"]
 [ext_resource type="PackedScene" uid="uid://qne2s471ofnd" path="res://Projectile.tscn" id="2_7drhp"]
+[ext_resource type="Shader" uid="uid://bfp6jig4ck14d" path="res://PlayerHitFlash.tres" id="3_mo1ji"]
 [ext_resource type="PackedScene" uid="uid://deh6r6fafabdq" path="res://Explosion.tscn" id="3_y67sl"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_qfnpy"]
+shader = ExtResource("3_mo1ji")
+shader_parameter/Enabled = false
+shader_parameter/HitColor = Color(1, 0, 0, 1)
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_xk8wl"]
 animations = [{
@@ -16,6 +22,43 @@ animations = [{
 "speed": 5.0
 }]
 
+[sub_resource type="Animation" id="Animation_6xw70"]
+resource_name = "hit"
+length = 0.2
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:material:shader_parameter/Enabled")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
+
+[sub_resource type="Animation" id="Animation_i8sti"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:material:shader_parameter/Enabled")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_rve81"]
+_data = {
+"RESET": SubResource("Animation_i8sti"),
+"hit": SubResource("Animation_6xw70")
+}
+
 [node name="Player" type="Area2D"]
 position = Vector2(340, 238)
 collision_mask = 40
@@ -24,12 +67,19 @@ ProjectileScene = ExtResource("2_7drhp")
 metadata/_edit_group_ = true
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
+visible = false
 polygon = PackedVector2Array(0, -18, -18, 2, -6, 16, 6, 16, 18, 1, 0, -18)
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+material = SubResource("ShaderMaterial_qfnpy")
 scale = Vector2(0.15, 0.15)
 sprite_frames = SubResource("SpriteFrames_xk8wl")
 
 [node name="Explosion" parent="." instance=ExtResource("3_y67sl")]
+
+[node name="HitAnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_rve81")
+}
 
 [connection signal="body_entered" from="." to="." method="OnBodyEntered"]

--- a/PlayerHitFlash.tres
+++ b/PlayerHitFlash.tres
@@ -1,0 +1,75 @@
+[gd_resource type="VisualShader" load_steps=5 format=3 uid="uid://bfp6jig4ck14d"]
+
+[sub_resource type="VisualShaderNodeColorParameter" id="VisualShaderNodeColorParameter_6gejf"]
+parameter_name = "HitColor"
+default_value_enabled = true
+default_value = Color(1, 0, 0, 1)
+
+[sub_resource type="VisualShaderNodeBooleanParameter" id="VisualShaderNodeBooleanParameter_hr5he"]
+parameter_name = "Enabled"
+
+[sub_resource type="VisualShaderNodeIf" id="VisualShaderNodeIf_2onky"]
+default_input_values = [0, 0.0, 1, 1.0, 2, 1e-05, 3, Vector3(0, 0, 0), 4, Vector3(0, 0, 0), 5, Vector3(0, 0, 0)]
+
+[sub_resource type="VisualShaderNodeInput" id="VisualShaderNodeInput_m27bn"]
+input_name = "color"
+
+[resource]
+code = "shader_type canvas_item;
+render_mode blend_mix;
+
+uniform bool Enabled;
+uniform vec4 HitColor : source_color = vec4(1.000000, 0.000000, 0.000000, 1.000000);
+
+
+
+void fragment() {
+// BooleanParameter:3
+	bool n_out3p0 = Enabled;
+
+
+// ColorParameter:2
+	vec4 n_out2p0 = HitColor;
+
+
+// Input:5
+	vec4 n_out5p0 = COLOR;
+
+
+	vec3 n_out4p0;
+// If:4
+	float n_in4p1 = 1.00000;
+	float n_in4p2 = 0.00001;
+	if(abs((n_out3p0 ? 1.0 : 0.0) - n_in4p1) < n_in4p2)
+	{
+		n_out4p0 = vec3(n_out2p0.xyz);
+	}
+	else if((n_out3p0 ? 1.0 : 0.0) < n_in4p1)
+	{
+		n_out4p0 = vec3(n_out5p0.xyz);
+	}
+	else
+	{
+		n_out4p0 = vec3(n_out5p0.xyz);
+	}
+
+
+// Output:0
+	COLOR.rgb = n_out4p0;
+
+
+}
+"
+graph_offset = Vector2(-300.187, -78.9477)
+mode = 1
+flags/light_only = false
+nodes/fragment/0/position = Vector2(720, 240)
+nodes/fragment/2/node = SubResource("VisualShaderNodeColorParameter_6gejf")
+nodes/fragment/2/position = Vector2(-220, 360)
+nodes/fragment/3/node = SubResource("VisualShaderNodeBooleanParameter_hr5he")
+nodes/fragment/3/position = Vector2(-220, 80)
+nodes/fragment/4/node = SubResource("VisualShaderNodeIf_2onky")
+nodes/fragment/4/position = Vector2(280, -20)
+nodes/fragment/5/node = SubResource("VisualShaderNodeInput_m27bn")
+nodes/fragment/5/position = Vector2(-240, 680)
+nodes/fragment/connections = PackedInt32Array(3, 0, 4, 0, 2, 0, 4, 3, 4, 0, 0, 0, 5, 0, 4, 4, 5, 0, 4, 5)

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,8 @@
 - Add UI for tracking score and health [X]
 - Add bunker scene [X]
 - Add particle effects [X]
-- Use shader to indicate when Player is hit [ ]
+- Use shader to indicate when Player is hit [X]
 - Add background [X]
 - Add music and sfx []
 - Add variety of invader assets []
+- Add additional levels (decrease invader shoot cooldown, add additional bunkers)


### PR DESCRIPTION
Uses the Shader material on the Player to setup a "hit" shader. 

Once the Shader material and the shader itself have been selected you use the shader editor tab at the bottom to add nodes to the shader itself. 
In this case to make it work we chain together a few nodes. 
- Add a ColorParameter node and set it to red. This is the node we want to activate when we get hit to turn the Player sprite red. 
- Add a BooleanParameter node to control when its active / inactive. This breaks our default sprite though as the base case isn't aware of the original sprite color.
- Add an If node which will receive input from the BooleanParameter and the ColorParameter and push output to the Output Color. 
- Add an Input node to feed into the base case of the If node (aka inactive state of the shader). 

Once that has been completed we need a way to "play" the shader. 
- Create an AnimationPlayer off of Player
- Inside our AnimatedSprite we can key off of our shader by clicking the Animation tab at the bottom and the little key icon next to the Enabled property on our shader. 
- After that we can set the keyframe to active, select the length of the animation, and set another keyframe to disable the animation. 

Finally, all we need to do is invoke the Play method on our AnimationPlayer on Player hit to trigger the shader. 
